### PR TITLE
Progress toward working vn_entr canonicalization

### DIFF
--- a/cvxpy/reductions/dcp2cone/atom_canonicalizers/vn_entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/atom_canonicalizers/vn_entr_canon.py
@@ -43,8 +43,9 @@ def vn_entr_canon(expr, args):
     con = Zero(trace(N) - sum(x))
     constrs.append(con)
 
-    # x[1:] >= x[:(n-1)]
-    con = NonPos(x[:(n-1)] - x[1:])
+    # x[:(n-1)] >= x[1:]
+    #   x[0] >= x[1],  x[1] >= x[2], ...
+    con = NonPos(x[1:] - x[:(n - 1)])
     constrs.append(con)
 
     # END code that applies to all spectral functions #

--- a/cvxpy/tests/test_vn_entr.py
+++ b/cvxpy/tests/test_vn_entr.py
@@ -23,8 +23,11 @@ from cvxpy.tests import solver_test_helpers as STH
 
 class Test_vn_entr:
 
-    SCS_ARGS = {'solver': 'SCS', 'eps': 1e-6, 'max_iters': 500_000,
-                'verbose': True}
+    if 'MOSEK' in cp.installed_solvers():
+        SOLVE_ARGS = {'solver': 'MOSEK', 'verbose': True}
+    else:
+        SOLVE_ARGS = {'solver': 'SCS', 'eps': 1e-6, 'max_iters': 500_000,
+                      'verbose': True}
 
     @staticmethod
     def make_test_1():
@@ -34,13 +37,11 @@ class Test_vn_entr:
         expect_N = np.array([[0.36787973, 0.00099987],
                              [0.00099987, 0.36787973]])
         eps = 1e2
-        cons1 = N >> 0
         cons2 = N << eps*np.eye(N.shape[0])
-        cons3 = N[1][0] == 1e-3
+        cons3 = N[1, 0] == 1e-3
         objective = cp.Maximize(vn_entr(N))
         obj_pair = (objective, 0.735756164739688)
         con_pairs = [
-            (cons1, None),
             (cons2, None),
             (cons3, None)
         ]
@@ -52,7 +53,7 @@ class Test_vn_entr:
 
     def test_1(self):
         sth = Test_vn_entr.make_test_1()
-        sth.solve(**self.SCS_ARGS)
+        sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
@@ -64,15 +65,13 @@ class Test_vn_entr:
         expect_N = np.array([[3.66497984e-01, -9.66999473e-14, 9.99852746e-03],
                              [-9.66999473e-14, 3.70615053e-01, -3.41058370e-13],
                              [9.99852746e-03, -3.41058370e-13, 3.66497984e-01]])
-        eps = 1e3
-        cons1 = N >> 0
-        cons2 = N << eps*np.eye(N.shape[0])
-        cons3 = N[2][0] == 1e-2
+        # eps = 1e2
+        # cons2 = N << eps*np.eye(N.shape[0])
+        cons3 = N[2, 0] == 1e-2
         objective = cp.Maximize(vn_entr(N))
         obj_pair = (objective, 1.103350176968849)
         con_pairs = [
-            (cons1, None),
-            (cons2, None),
+            # (cons2, None),
             (cons3, None)
         ]
         var_pairs = [
@@ -83,7 +82,7 @@ class Test_vn_entr:
 
     def test_2(self):
         sth = Test_vn_entr.make_test_2()
-        sth.solve(**self.SCS_ARGS)
+        sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
@@ -98,26 +97,24 @@ class Test_vn_entr:
                                   [1, 0, 0],
                                   [0, 0, 1]]))
         eps = 1e3
-        cons1 = N >> 0
         cons2 = N << eps*np.eye(N.shape[0])
-        cons3 = N[2][0] == 1e-2
-        N = U.T@N@U
-        objective = cp.Maximize(vn_entr(N))
+        cons3 = N[2, 0] == 1e-2
+        N_conj = U.T @ N @ U
+        objective = cp.Maximize(vn_entr(N_conj))
         obj_pair = (objective, 1.1033501770078251)
         con_pairs = [
-            (cons1, None),
             (cons2, None),
             (cons3, None)
         ]
         var_pairs = [
-            (N, expect_N)
+            (N_conj, expect_N)
         ]
         sth = STH.SolverTestHelper(obj_pair, var_pairs, con_pairs)
         return sth
 
     def test_3(self):
         sth = Test_vn_entr.make_test_3()
-        sth.solve(**self.SCS_ARGS)
+        sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
@@ -129,7 +126,6 @@ class Test_vn_entr:
         expect_N = np.array([[2.99999997e+00, -1.59980927e-15, 1.81681520e-08],
                              [-1.59980927e-15, 2.99990732e+00, 1.61179597e-15],
                              [1.81681520e-08, 1.61179597e-15, 2.99999997e+00]])
-        cons1 = N >> 0
         v = cp.Constant(np.array([1, 0, 1]))
         mu = 3
         cons2 = N @ v == mu * v
@@ -137,7 +133,6 @@ class Test_vn_entr:
         objective = cp.Maximize(vn_entr(N))
         obj_pair = (objective, -9.887315950231013)
         con_pairs = [
-            (cons1, None),
             (cons2, None),
             (cons3, None)
         ]
@@ -149,6 +144,6 @@ class Test_vn_entr:
 
     def test_4(self):
         sth = Test_vn_entr.make_test_4()
-        sth.solve(**self.SCS_ARGS)
+        sth.solve(**self.SOLVE_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)

--- a/cvxpy/tests/test_vn_entr.py
+++ b/cvxpy/tests/test_vn_entr.py
@@ -22,6 +22,10 @@ from cvxpy.tests import solver_test_helpers as STH
 
 
 class Test_vn_entr:
+
+    SCS_ARGS = {'solver': 'SCS', 'eps': 1e-6, 'max_iters': 500_000,
+                'verbose': True}
+
     @staticmethod
     def make_test_1():
         """(2,2) matrix, 100 largest ev, 1e-3 off-diagonal element"""
@@ -48,7 +52,7 @@ class Test_vn_entr:
 
     def test_1(self):
         sth = Test_vn_entr.make_test_1()
-        sth.solve(solver='SCS')
+        sth.solve(**self.SCS_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
@@ -79,7 +83,7 @@ class Test_vn_entr:
 
     def test_2(self):
         sth = Test_vn_entr.make_test_2()
-        sth.solve(solver='SCS')
+        sth.solve(**self.SCS_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
@@ -113,7 +117,7 @@ class Test_vn_entr:
 
     def test_3(self):
         sth = Test_vn_entr.make_test_3()
-        sth.solve(solver='SCS')
+        sth.solve(**self.SCS_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)
 
@@ -145,6 +149,6 @@ class Test_vn_entr:
 
     def test_4(self):
         sth = Test_vn_entr.make_test_4()
-        sth.solve(solver='SCS')
+        sth.solve(**self.SCS_ARGS)
         sth.verify_objective(places=3)
         sth.verify_primal_values(places=3)


### PR DESCRIPTION
The tests don't pass as-written, but they produce sane results. You'll need to modify the tests.

I also suggest you design problems so you can find an analytic solution. For example, if you have have an $n \times n$ matrix and specify $n-1$ of its eigenvectors and eigenvalues, then you actually know the final eigenvector up to a sign change (since the orthogonal complement of an $(n-1)$ dimensional space in $\mathbb{R}^n$ is 1-dimensional). If you set the objective to $\max(-\rho \log \rho)$ for the psd matrix variable $\rho$ then the only room left for optimization is the single unspecified eigenvalue $\lambda_{\text{unspec}}$, and the goal will be to maximize $-\lambda_{\text{unspec}}\log(\lambda_{\text{unspec}})$, which occurs at $\lambda_{\text{unspec}} = 1/e$.