### PR TITLE
Get test to pass with ExpConeQuad

### DIFF
--- a/cvxpy/constraints/exponential.py
+++ b/cvxpy/constraints/exponential.py
@@ -100,8 +100,8 @@ class ExpCone(Constraint):
         """
         return self.x.size
 
-    def ExpCone2ExpConeQuad(self, m: int, k: int) -> ExpConeQuad:
-        return ExpConeQuad(self.x, self.y, -self.z, m, k)
+    def as_expconequad(self, m: int, k: int) -> ExpConeQuad:
+        return ExpConeQuad(self.y, self.z, -self.x, m, k)
 
     def cone_sizes(self) -> List[int]:
         """The dimensions of the exponential cones.

--- a/cvxpy/reductions/cone2cone/common2common.py
+++ b/cvxpy/reductions/cone2cone/common2common.py
@@ -72,7 +72,7 @@ def ExpConeQuad_canon(con: ExpConeQuad, args) -> Tuple[Constraint, List[Constrai
     Z = Variable(shape=(k+1,))
     w, t = gauss_legendre(m)
     T = Variable(m)
-    lead_con = Zero(w @ T + T/2**k)
+    lead_con = Zero(w @ T + con.z/2**k)
     constrs = [Zero(Z[0] - y)]
 
     for i in range(k):

--- a/cvxpy/tests/test_cone2cone.py
+++ b/cvxpy/tests/test_cone2cone.py
@@ -492,10 +492,15 @@ class TestExpConeQuad(BaseTest):
         min   3 * x[0] + 2 * x[1] + x[2]
         s.t.  0.1 <= x[0] + x[1] + x[2] <= 1
               x >= 0
-              x[0] >= x[1] * exp(x[2] / x[1])
+              and ...
+                x[0] >= x[1] * exp(x[2] / x[1])
+              equivalently ...
+                x[0] / x[1] >= exp(x[2] / x[1])
+                log(x[0] / x[1]) >= x[2] / x[1]
+                x[1] log(x[1] / x[0]) <= -x[2]
         """
         x = cp.Variable(shape=(3, 1))
-        cone_con = cp.constraints.ExpConeQuad(x[2], x[1], x[0], 5, 5)
+        cone_con = ExpCone(x[2], x[1], x[0]).as_expconequad(5, 5)
         constraints = [cp.sum(x) <= 1.0,
                        cp.sum(x) >= 0.1,
                        x >= 0,


### PR DESCRIPTION
The problem was that for ``ExpCone(x, y, z)`` we actually needed an ``ExpConeQuad(y, z, -x)``, while ...
1. ``ExpCone.ExpCone2ExpConeQuad`` was returning ``ExpConeQuad(x, y, -z)``.
2. The test had just replaced ``ExpCone(x, y, z)`` with ``ExpConeQuad(x, y, z)``.

I also restored the use of ``con.z`` instead of ``T`` in the main equality constraint, since our ``con.z`` maps to the paper's ``T`` (with no subscript).