### PR TITLE
Hermitian quad

### DIFF
--- a/cvxpy/reductions/complex2real/atom_canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/atom_canonicalizers/__init__.py
@@ -94,7 +94,7 @@ CANON_METHODS = {
     PSD: psd_canon,
     SOC: soc_canon,
     Equality: equality_canon,
-    Zero: equality_canon,
+    Zero: zero_canon,
 
     abs: abs_canon,
     norm1: pnorm_canon,

--- a/cvxpy/reductions/solvers/solving_chain.py
+++ b/cvxpy/reductions/solvers/solving_chain.py
@@ -276,6 +276,11 @@ def construct_solving_chain(problem, candidates,
                 reductions.append(Exotic2Common())
             if RelEntrQuad in approx_cos or OpRelConeQuad in approx_cos:
                 reductions.append(QuadApprox())
+                from cvxpy.reductions.complex2real.complex2real import Complex2Real
+                reductions_filter = [r for r in reductions if not isinstance(r, Complex2Real)]
+                if len(reductions_filter) < len(reductions):
+                    reductions = reductions_filter
+                    reductions.append(Complex2Real())
 
             # Should the objective be canonicalized to a quadratic?
             if solver_opts is None:


### PR DESCRIPTION
This changes the placement of the ``Complex2Real`` reduction when we hit the ``QuadApprox`` canonicalization path with complex data. This also includes a one-line change to the dispatcher for the ``Zero`` constraint canonicalizer.