### PR TITLE
Hermitian args in quantum_rel_entr

### DIFF
--- a/cvxpy/atoms/quantum_rel_entr.py
+++ b/cvxpy/atoms/quantum_rel_entr.py
@@ -68,7 +68,7 @@ class quantum_rel_entr(Atom):
     def is_atom_convex(self) -> bool:
         """Is the atom convex?
         """
-        return True
+        return False
 
     def shape_from_args(self) -> Tuple[int, ...]:
         """Returns the shape of the expression.
@@ -78,7 +78,7 @@ class quantum_rel_entr(Atom):
     def is_atom_concave(self) -> bool:
         """Is the atom concave?
         """
-        return False
+        return True
 
     def is_incr(self, idx) -> bool:
         """Is the composition non-decreasing in argument idx?

--- a/cvxpy/reductions/complex2real/canonicalizers/__init__.py
+++ b/cvxpy/reductions/complex2real/canonicalizers/__init__.py
@@ -18,7 +18,7 @@ from cvxpy.atoms import (MatrixFrac, Pnorm, QuadForm, abs, bmat, conj, conv,
                          cumsum, imag, kron, lambda_max, lambda_sum_largest,
                          log_det, norm1, norm_inf, quad_over_lin, real,
                          reshape, sigma_max, trace, upper_tri,
-                         von_neumann_entr,)
+                         von_neumann_entr, quantum_rel_entr)
 from cvxpy.atoms.affine.add_expr import AddExpression
 from cvxpy.atoms.affine.binary_operators import (DivExpression, MulExpression,
                                                  multiply,)
@@ -49,7 +49,7 @@ from cvxpy.reductions.complex2real.canonicalizers.inequality_canon import (
 from cvxpy.reductions.complex2real.canonicalizers.matrix_canon import (
     hermitian_canon, lambda_sum_largest_canon, matrix_frac_canon,
     norm_nuc_canon, op_rel_entr_cone_canon, quad_canon, quad_over_lin_canon,
-    trace_canon, von_neumann_entr_canon,)
+    trace_canon, von_neumann_entr_canon, quantum_rel_entr_canon)
 from cvxpy.reductions.complex2real.canonicalizers.param_canon import (
     param_canon,)
 from cvxpy.reductions.complex2real.canonicalizers.pnorm_canon import (
@@ -111,4 +111,5 @@ CANON_METHODS = {
     lambda_sum_largest: lambda_sum_largest_canon,
     OpRelEntrConeQuad: op_rel_entr_cone_canon,
     von_neumann_entr: von_neumann_entr_canon,
+    quantum_rel_entr: quantum_rel_entr_canon
 }

--- a/cvxpy/reductions/dcp2cone/canonicalizers/quantum_rel_entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/quantum_rel_entr_canon.py
@@ -1,23 +1,45 @@
+import numpy as np
+
+import cvxpy as cp
 from cvxpy import Variable
 from cvxpy.atoms.affine.kron import kron
 from cvxpy.constraints import OpRelEntrConeQuad
-from cvxpy.reductions.cone2cone.approximations import gauss_legendre
 
-import cvxpy as cp
-import numpy as np
 
 def quantum_rel_entr_canon(expr, args):
-    constrs = []
     X, Y = args
     n = X.shape[0]
-    I = np.eye(n)
-    e = I.ravel().reshape(n ** 2, 1)
-    first_arg = cp.atoms.affine.wraps.symmetric_wrap(kron(X, I))
-    second_arg = cp.atoms.affine.wraps.symmetric_wrap(kron(I, Y.conj()))
-    epi = Variable(shape=first_arg.shape, symmetric=True)
-    constrs.append(OpRelEntrConeQuad(first_arg, second_arg, epi,
-                                     expr.quad_approx[0], expr.quad_approx[1]))
-    return e.T @ epi @ e, constrs
+    Imat = np.eye(n)
+    e = Imat.ravel().reshape(n ** 2, 1)
+    if (not X.is_real()) or (not Y.is_real()):
+        assert X.is_hermitian()
+        assert Y.is_hermitian()
+        first_arg = cp.atoms.affine.wraps.hermitian_wrap(kron(X, Imat))
+        second_arg = cp.atoms.affine.wraps.hermitian_wrap(kron(Imat, Y.conj()))
+        epi = Variable(shape=first_arg.shape, hermitian=True)
+        # TODO
+        #   1. appropriately canonicalize first_arg, second_arg, and epi
+        #      into real and imaginary parts.
+        #   2. call the op_rel_entr_cone_canon function from
+        #       cvxpy/reductions/complex2real/canonicalizers/matrix_canon.py
+        #   3. extract the equivalent real OpRelEntrConeQuad constraint.
+        raise NotImplementedError('Finish me!')
+    else:
+        assert X.is_symmetric()
+        assert Y.is_symmetric()
+        first_arg = cp.atoms.affine.wraps.symmetric_wrap(kron(X, Imat))
+        second_arg = cp.atoms.affine.wraps.symmetric_wrap(kron(Imat, Y))
+        epi = Variable(shape=first_arg.shape, symmetric=True)
+        orec_con = OpRelEntrConeQuad(first_arg, second_arg, epi,
+                                     expr.quad_approx[0], expr.quad_approx[1]
+        )
+    # at this point we can be certain that we're dealing with an OpRelEnterConeQuad
+    # constraint with real inputs. Canonicalize it, and return the results!
+    main_con, aux_cons = cp.reductions.cone2cone.approximations.OpRelEntrConeQuad_canon(
+        orec_con, None
+    )
+    constrs = [main_con] + aux_cons
+    return -e.T @ epi @ e, constrs
 
 
 ### Attempt at implementing smaller canonicalization of P(r_m)

--- a/cvxpy/reductions/dcp2cone/canonicalizers/quantum_rel_entr_canon.py
+++ b/cvxpy/reductions/dcp2cone/canonicalizers/quantum_rel_entr_canon.py
@@ -11,28 +11,14 @@ def quantum_rel_entr_canon(expr, args):
     n = X.shape[0]
     Imat = np.eye(n)
     e = Imat.ravel().reshape(n ** 2, 1)
-    if (not X.is_real()) or (not Y.is_real()):
-        assert X.is_hermitian()
-        assert Y.is_hermitian()
-        first_arg = cp.atoms.affine.wraps.hermitian_wrap(kron(X, Imat))
-        second_arg = cp.atoms.affine.wraps.hermitian_wrap(kron(Imat, Y.conj()))
-        epi = Variable(shape=first_arg.shape, hermitian=True)
-        # TODO
-        #   1. appropriately canonicalize first_arg, second_arg, and epi
-        #      into real and imaginary parts.
-        #   2. call the op_rel_entr_cone_canon function from
-        #       cvxpy/reductions/complex2real/canonicalizers/matrix_canon.py
-        #   3. extract the equivalent real OpRelEntrConeQuad constraint.
-        raise NotImplementedError('Finish me!')
-    else:
-        assert X.is_symmetric()
-        assert Y.is_symmetric()
-        first_arg = cp.atoms.affine.wraps.symmetric_wrap(kron(X, Imat))
-        second_arg = cp.atoms.affine.wraps.symmetric_wrap(kron(Imat, Y))
-        epi = Variable(shape=first_arg.shape, symmetric=True)
-        orec_con = OpRelEntrConeQuad(first_arg, second_arg, epi,
-                                     expr.quad_approx[0], expr.quad_approx[1]
-        )
+    assert X.is_symmetric()
+    assert Y.is_symmetric()
+    first_arg = cp.atoms.affine.wraps.symmetric_wrap(kron(X, Imat))
+    second_arg = cp.atoms.affine.wraps.symmetric_wrap(kron(Imat, Y))
+    epi = Variable(shape=first_arg.shape, symmetric=True)
+    orec_con = OpRelEntrConeQuad(first_arg, second_arg, epi,
+                                 expr.quad_approx[0], expr.quad_approx[1]
+    )
     # at this point we can be certain that we're dealing with an OpRelEnterConeQuad
     # constraint with real inputs. Canonicalize it, and return the results!
     main_con, aux_cons = cp.reductions.cone2cone.approximations.OpRelEntrConeQuad_canon(


### PR DESCRIPTION
This is my attempt at getting complex args to work with quantum_rel_entr. I've verified that it produces reasonable output for the following test problem:

```python

import numpy as np
import cvxpy as cp


np.random.seed(0)
n = 2
X = cp.Variable(shape=(n, n), hermitian=True)
A = np.random.randn(n, n)

obj_expr = cp.quantum_rel_entr(X, np.eye(n))
obj = cp.Maximize(obj_expr)
cons = [
    X >> 0,
    cp.norm(X @ A) <= 10
]

prob = cp.Problem(obj, cons)
prob.solve(solver='CLARABEL', verbose=True)
```